### PR TITLE
Update readme and add a docker image publishing action.

### DIFF
--- a/.github/workflows/docker-image-publish.yml
+++ b/.github/workflows/docker-image-publish.yml
@@ -1,0 +1,60 @@
+#
+name: Create and publish a Docker image
+
+# Configures this workflow to run every time a change is pushed to the branch called `release`.
+on:
+  push:
+    branches: ['image-creation-test']
+
+# Defines two custom environment variables for the workflow. These are used for the Container registry domain, and a name for the Docker image that this workflow builds.
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+# There is a single job in this workflow. It's configured to run on the latest available version of Ubuntu.
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+      # 
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      # Uses the `docker/login-action` action to log in to the Container registry registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      # This step uses [docker/metadata-action](https://github.com/docker/metadata-action#about) to extract tags and labels that will be applied to the specified image. The `id` "meta" allows the output of this step to be referenced in a subsequent step. The `images` value provides the base name for the tags and labels.
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
+      # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see "[Usage](https://github.com/docker/build-push-action#usage)" in the README of the `docker/build-push-action` repository.
+      # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+      
+      # This step generates an artifact attestation for the image, which is an unforgeable statement about where and how it was built. It increases supply chain security for people who consume the image. For more information, see "[AUTOTITLE](/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds)." 
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true
+      

--- a/.github/workflows/docker-image-publish.yml
+++ b/.github/workflows/docker-image-publish.yml
@@ -4,7 +4,7 @@ name: Create and publish a Docker image
 # Configures this workflow to run every time a change is pushed to the branch called `release`.
 on:
   push:
-    branches: ['image-creation-test']
+    branches: ['release']
 
 # Defines two custom environment variables for the workflow. These are used for the Container registry domain, and a name for the Docker image that this workflow builds.
 env:

--- a/.github/workflows/docker-image-publish.yml
+++ b/.github/workflows/docker-image-publish.yml
@@ -15,16 +15,18 @@ env:
 jobs:
   build-and-push-image:
     runs-on: ubuntu-latest
+
     # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
     permissions:
       contents: read
       packages: write
       attestations: write
       id-token: write
-      # 
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
       # Uses the `docker/login-action` action to log in to the Container registry registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
       - name: Log in to the Container registry
         uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
@@ -32,12 +34,17 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
       # This step uses [docker/metadata-action](https://github.com/docker/metadata-action#about) to extract tags and labels that will be applied to the specified image. The `id` "meta" allows the output of this step to be referenced in a subsequent step. The `images` value provides the base name for the tags and labels.
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            latest
+            type=sha
+
       # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
       # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see "[Usage](https://github.com/docker/build-push-action#usage)" in the README of the `docker/build-push-action` repository.
       # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
@@ -49,12 +56,12 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-      
+
       # This step generates an artifact attestation for the image, which is an unforgeable statement about where and how it was built. It increases supply chain security for people who consume the image. For more information, see "[AUTOTITLE](/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds)." 
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v1
         with:
-          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true
       

--- a/.github/workflows/docker-image-publish.yml
+++ b/.github/workflows/docker-image-publish.yml
@@ -64,4 +64,3 @@ jobs:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true
-      

--- a/README.md
+++ b/README.md
@@ -1,3 +1,47 @@
 # Mark XIV Thermocoil Boilmaster
 
 Web service for Final Fantasy XIV game data and asset discovery.
+
+## Installation
+
+### Building From Source
+
+**Requirements**
+ - [Rust](https://www.rust-lang.org/tools/install)
+
+```
+git clone https://github.com/ackwell/boilmaster
+cd boilmaster
+cargo run --release
+```
+
+It is recommended to edit your config in `boilmaster.toml` and change the admin username and password.
+
+### Docker Usage
+
+First we set up a working directory and prepare our config.
+```
+mkdir boilmaster
+cd boilmaster
+curl --create-dirs -O --output-dir config https://raw.githubusercontent.com/ackwell/boilmaster/main/boilmaster.toml
+```
+Then we can create a `docker-compose.yml` using the example below:
+```
+services:
+  boilmaster:
+    image: ghcr.io/arcanedisgea/boilmaster:image-creation-test
+    container_name: boilmaster
+    environment:
+     - BM_HTTP_ADMIN_AUTH_USERNAME="CHANGE-ME"
+     - BM_HTTP_ADMIN_AUTH_PASSWORD="CHANGE-ME"
+      # Other configuration here, see [[path to config docs]] for options
+    volumes:
+      - ${PWD}/versions:/app/versions
+      - ${PWD}/exdschema:/app/exdschema
+      - ${PWD}/search:/app/search
+      # Need roughly 100gb of free space for patches
+      - ${PWD}/patches:/app/patches
+    ports:
+      - 8080:8080
+    restart: unless-stopped
+```

--- a/README.md
+++ b/README.md
@@ -7,41 +7,45 @@ Web service for Final Fantasy XIV game data and asset discovery.
 ### Building From Source
 
 **Requirements**
- - [Rust](https://www.rust-lang.org/tools/install)
+ - [Rust](https://www.rust-lang.org/tools/install) >= 1.77.2
 
-```
+```bash
 git clone https://github.com/ackwell/boilmaster
 cd boilmaster
 cargo run --release
 ```
 
-It is recommended to edit your config in `boilmaster.toml` and change the admin username and password.
+It is recommended to edit your config in `boilmaster.toml` and at minimum change the admin username and password. See [the configuration section](#configuration) for more information.
 
 ### Docker Usage
 
-First we set up a working directory and prepare our config.
-```
-mkdir boilmaster
-cd boilmaster
-curl --create-dirs -O --output-dir config https://raw.githubusercontent.com/ackwell/boilmaster/main/boilmaster.toml
-```
-Then we can create a `docker-compose.yml` using the example below:
-```
+boilmaster is published as a Docker image on the github container registery. An example `docker-compose.yml` such as the below can be used to bring the service online.
+
+```yml
 services:
   boilmaster:
-    image: ghcr.io/ackwell/boilmaster:release
+    image: ghcr.io/ackwell/boilmaster:latest
     container_name: boilmaster
     environment:
      - BM_HTTP_ADMIN_AUTH_USERNAME="CHANGE-ME"
      - BM_HTTP_ADMIN_AUTH_PASSWORD="CHANGE-ME"
-      # Other configuration here, see [[path to config docs]] for options
+      # Other configuration here, see the Configuration section below for more information.
     volumes:
       - ${PWD}/versions:/app/versions
       - ${PWD}/exdschema:/app/exdschema
-      - ${PWD}/search:/app/search
       # Need roughly 100gb of free space for patches
       - ${PWD}/patches:/app/patches
     ports:
       - 8080:8080
     restart: unless-stopped
 ```
+
+## Configuration
+
+The default configuration for boilmaster can be found in `boilmaster.toml`. This file can be considered a source of truth for all configuration options available.
+
+In addition to the configuration file, all options may also be set via environment variables. The name of these variables is the same as their path in TOML; replacing `.` with `_`, in uppercase, with the prefix `BM_`. i.e. the config file key `http.api1.sheet.limit.default` can be set with the environment variable `BM_HTTP_API1_SHEET_LIMIT_DEFAULT`.
+
+Configuration is only read during application startup, a restart is required if changes are made.
+
+Before exposing the service to the public, it is strongly advised to change the `http.admin.auth.username` and `http.admin.auth.password` values.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Then we can create a `docker-compose.yml` using the example below:
 ```
 services:
   boilmaster:
-    image: ghcr.io/arcanedisgea/boilmaster:image-creation-test
+    image: ghcr.io/ackwell/boilmaster:release
     container_name: boilmaster
     environment:
      - BM_HTTP_ADMIN_AUTH_USERNAME="CHANGE-ME"


### PR DESCRIPTION
As discussed in discord this is an update to the readme to provide better documentation for running boilmaster as well as an automated docker image publishing solution using Github Container Registry.