### PR TITLE
Add additional overrides for ffxiv HIST patches

### DIFF
--- a/boilmaster.toml
+++ b/boilmaster.toml
@@ -57,7 +57,7 @@ endpoint = "https://thaliak.xiv.dev/graphql/2022-08-14"
 # Thaliak bugged out and failed to link between the last delta patch, and the history patches, at 7.0.
 # This is just a manual specification of those links to restore the patch chain.
 [version.thaliak.overrides]
-4e9a232b = { "2024.05.31.0000.0000" = "H2024.05.31.0000.0000z" }
+4e9a232b = { "2024.05.31.0000.0000" = "H2024.05.31.0000.0000ag", "H2024.05.31.0000.0000aa" = "H2024.05.31.0000.0000z", "H2024.05.31.0000.0000b" = "H2024.05.31.0000.0000a" }
 6b936f08 = { "2024.05.31.0000.0000" = "H2024.05.31.0000.0000d" }
 f29a3eb2 = { "2024.05.31.0000.0000" = "H2024.05.31.0000.0000e" }
 859d0e24 = { "2024.05.31.0000.0000" = "H2024.05.31.0000.0000g" }


### PR DESCRIPTION
Thaliak uses lexicographical ordering, instead of the order from the patchlist, which means that HIST patches are not ordered correctly (H-a, H-aa, H-ab, ..., H-b instead of H-a, H-b, ..., H-z, H-aa).

This is not a problem, except for one specific case: The aa and ab patches write data to `060000.win32.dat3`, which, under normal circumstances, would be fine. However, the z patch sets up this file and writes some zero bytes. With the incorrect order, the correct data written by the aN patches is cleared by the z patch.